### PR TITLE
Create macadmins-slack-rss-archive.md

### DIFF
--- a/macadmins-slack-rss-archive.md
+++ b/macadmins-slack-rss-archive.md
@@ -13,9 +13,6 @@ This file exists to enable rapid rebuilds if Slack RSS integrations are lost.
 
 ## #blog-feed
 
-- **9to5Mac**  
-  http://9to5mac.com/feed.xml
-
 - **Apple Newsroom**  
   http://www.apple.com/pr/feeds/pr.rss
 
@@ -63,9 +60,6 @@ This file exists to enable rapid rebuilds if Slack RSS integrations are lost.
 
 - **Jamf Blog**  
   http://www.jamf.com/blog/rss/
-
-- **Jamf Press Releases**  
-  https://www.jamf.com/press-releases/rss/
 
 - **krypted**  
   http://krypted.com/feed/
@@ -131,7 +125,20 @@ This file exists to enable rapid rebuilds if Slack RSS integrations are lost.
 - **mike solin's blog**  
   https://mikesolin.com/feed/
 
+---
 
+## #apple-rumors
+
+- **9to5Mac**  
+  http://9to5mac.com/feed.xml
+
+- **MacRumors: Mac News and Rumors**  
+  https://feeds.macrumors.com/MacRumors-All 
+  
+  - **Jamf Press Releases**  
+  https://www.jamf.com/press-releases/rss/
+  
+  
 ---
 
 ## #jamfnation
@@ -188,6 +195,12 @@ _No feeds assigned yet._
 - **Free Games Finders RSS Feed**  
   https://steamcommunity.com/groups/freegamesfinders/rss/
 
+---
+
+## #freegames-prime
+
+- **Free Amazon Prime Games (PC)*  
+  https://feed.eikowagenknecht.com/lootscraper_amazon_game.xml
 
 ---
 

--- a/macadmins-slack-rss-archive.md
+++ b/macadmins-slack-rss-archive.md
@@ -1,0 +1,235 @@
+# Mac Admins Slack – RSS Feeds Archive
+
+This document contains an archive of RSS feeds intended for use within the
+Mac Admins Slack workspace.
+
+Feeds are grouped by the Slack channels they post into. 
+
+This file exists to enable rapid rebuilds if Slack RSS integrations are lost.
+
+**Last Updated:** 2026-01-13
+
+---
+
+## #blog-feed
+
+- **9to5Mac**  
+  http://9to5mac.com/feed.xml
+
+- **Apple Newsroom**  
+  http://www.apple.com/pr/feeds/pr.rss
+
+- **Basic Apple Guy | Apple Wallpapers, Reviews, and Merch**  
+  https://www.basicappleguy.com/basicappleblog?format=rss
+  
+- **Greater Philadelphia Mac Admins**  
+  https://phillymacadmins.com/feed/
+
+- **Cannonball**  
+  http://cannonball.tombridge.com/feed/
+
+- **Command Control Power: Apple Tech Support & Business Talk**  
+  http://commandcontrolpower.com/podcast?format=RSS
+
+- **Command Line – OS X Daily**  
+  http://osxdaily.com/category/command-line/feed/
+  
+- **Patch Notes and Progress**  
+  https://tonyyo11.github.io/feed.xml  
+
+- **Dan K. Snelson**  
+  https://snelson.us/feed/
+
+- **Der Flounder**  
+  https://derflounder.wordpress.com/feed/
+
+- **graham gilbert**  
+  https://grahamgilbert.com/index.xml
+  
+- **managing devices.**  
+  https://www.lashomb.com/rss.xml
+  
+- **mike solin's blog**  
+  https://mikesolin.com/feed/
+  
+- **Year of The Geek**  
+  http://yearofthegeek.net/feed
+
+- **HCS Technology Group - Latest blog entries**  
+  https://hcsonline.com/support/blog?format=feed&type=rss
+
+- **HCS Technology Group - Technical Articles**  
+  https://hcsonline.com/support/white-papers?format=feed&type=rss
+
+- **Jamf Blog**  
+  http://www.jamf.com/blog/rss/
+
+- **Jamf Press Releases**  
+  https://www.jamf.com/press-releases/rss/
+
+- **krypted**  
+  http://krypted.com/feed/
+
+- **Latest News - Apple Developer**  
+  http://developer.apple.com/rss/iphonedevnews.rss
+
+- **Mac Admins Podcast**  
+  http://podcast.macadmins.org/feed/
+
+- **MacAdmins.news**  
+  https://macadmins.news/issues.rss
+
+- **macmule**  
+  http://macmule.com/feed/
+
+- **Macs – The Eclectic Light Company**  
+  https://eclecticlight.co/category/macs/feed/
+
+- **Managing OS X**  
+  http://managingosx.wordpress.com/feed/
+
+- **Marriott Library - Apple Infrastructure**  
+  https://apple.lib.utah.edu/feed/
+
+- **MOD TITAN**  
+  http://www.modtitan.com/feeds/posts/default?alt=rss
+
+- **Mr. Macintosh**  
+  https://mrmacintosh.com/feed/
+
+- **r/macsysadmin**  
+  https://api.reddit.com/subreddit/macsysadmin
+
+- **Richard Purves**  
+  hhttps://richard-purves.com/feed
+
+- **Scripting OS X**  
+  http://scriptingosx.com/feed/
+
+- **SecureMac**  
+  https://www.securemac.com/feed
+
+- **Sound Mac Guy**  
+  https://soundmacguy.wordpress.com/feed/
+
+- **Travelling Tech Guy**  
+  https://travellingtechguy.eu/feed/
+
+- **News From Timo**  
+  https://tperfitt.twocanoes.com/feed.xml
+  
+- **MacAdmin Musings**  
+  https://macadminmusings.com/feed.xml  
+
+- **What The Mac?!**  
+  http://grahampugh.github.io/feed.xml
+
+---
+
+## #blog-feed-lite
+
+- **mike solin's blog**  
+  https://mikesolin.com/feed/
+
+
+---
+
+## #jamfnation
+
+- **Jamf Status - Incident History**  
+  https://status.jamf.com/history.rss
+
+
+---
+
+## #jamf-community-post
+
+- **Jamf Blog**  
+  http://www.jamf.com/blog/rss/
+
+- **Jamf Press Releases**  
+  https://www.jamf.com/press-releases/rss/
+
+---
+
+## #apple-dev-rss
+
+- **Releases - Apple Developer**  
+  https://developer.apple.com/news/releases/rss/releases.rss
+
+
+---
+
+## #macadmpodcast
+
+- **Mac Admins Podcast**  
+  http://podcast.macadmins.org/feed/
+
+
+---
+
+## #sofa-rss-feed
+
+- **SOFA - RSS Update Feed**  
+  https://sofafeed.macadmins.io/v1/rss_feed.xml
+
+
+---
+
+## #security-alerts
+
+_No feeds assigned yet._
+
+
+---
+
+## #freegames
+
+- **Free Games Finders RSS Feed**  
+  https://steamcommunity.com/groups/freegamesfinders/rss/
+
+
+---
+
+## #philly
+
+- **Greater Philadelphia Mac Admins**  
+  https://phillymacadmins.com/feed/
+
+
+---
+
+## #meetups
+
+- **Greater Philadelphia Mac Admins**  
+  https://phillymacadmins.com/feed/
+
+---
+
+## #app-catalog-updates
+
+- **App Catalog**  
+  https://feedback.appcatalog.cloud/api/v1/changelog/feed.rss
+  
+  
+- **App Catalog**  
+  https://appcatalog.cloud/apps/rss.xml 
+
+
+---
+
+## #tailscale
+
+- **Changelog on Tailscale**  
+  https://tailscale.com/changelog/index.xml  
+  
+
+---
+
+## Unassigned / Needs Review
+
+---
+
+# CHANGELOG
+
+- 2026-01-13: Initial Generation of List. Tony Young @tonyyo11


### PR DESCRIPTION
This document contains an archive of RSS feeds intended for use within the Mac Admins Slack workspace.
Feeds are grouped by the Slack channels they post into. 
This file exists to enable rapid rebuilds if Slack RSS integrations are lost.