### PR TITLE
Audit and expand Slack RSS feed archive with new channels and updates

### DIFF
--- a/macadmins-slack-rss-archive.md
+++ b/macadmins-slack-rss-archive.md
@@ -3,159 +3,55 @@
 This document contains an archive of RSS feeds intended for use within the
 Mac Admins Slack workspace.
 
-Feeds are grouped by the Slack channels they post into. 
+Feeds are grouped by the Slack channels they post into.
 
 This file exists to enable rapid rebuilds if Slack RSS integrations are lost.
 
-**Last Updated:** 2026-01-13
+**Last Updated:** 2026-04-16
 
 ---
 
-## #blog-feed
+## #1password
 
-- **Apple Newsroom**  
-  http://www.apple.com/pr/feeds/pr.rss
-
-- **Basic Apple Guy | Apple Wallpapers, Reviews, and Merch**  
-  https://www.basicappleguy.com/basicappleblog?format=rss
-  
-- **Greater Philadelphia Mac Admins**  
-  https://phillymacadmins.com/feed/
-
-- **Cannonball**  
-  http://cannonball.tombridge.com/feed/
-
-- **Command Control Power: Apple Tech Support & Business Talk**  
-  http://commandcontrolpower.com/podcast?format=RSS
-
-- **Command Line – OS X Daily**  
-  http://osxdaily.com/category/command-line/feed/
-  
-- **Patch Notes and Progress**  
-  https://tonyyo11.github.io/feed.xml  
-
-- **Dan K. Snelson**  
-  https://snelson.us/feed/
-
-- **Der Flounder**  
-  https://derflounder.wordpress.com/feed/
-
-- **graham gilbert**  
-  https://grahamgilbert.com/index.xml
-  
-- **managing devices.**  
-  https://www.lashomb.com/rss.xml
-  
-- **mike solin's blog**  
-  https://mikesolin.com/feed/
-  
-- **Year of The Geek**  
-  http://yearofthegeek.net/feed
-
-- **HCS Technology Group - Latest blog entries**  
-  https://hcsonline.com/support/blog?format=feed&type=rss
-
-- **HCS Technology Group - Technical Articles**  
-  https://hcsonline.com/support/white-papers?format=feed&type=rss
-
-- **Jamf Blog**  
-  http://www.jamf.com/blog/rss/
-
-- **krypted**  
-  http://krypted.com/feed/
-
-- **Latest News - Apple Developer**  
-  http://developer.apple.com/rss/iphonedevnews.rss
-
-- **Mac Admins Podcast**  
-  http://podcast.macadmins.org/feed/
-
-- **MacAdmins.news**  
-  https://macadmins.news/issues.rss
-
-- **macmule**  
-  http://macmule.com/feed/
-
-- **Macs – The Eclectic Light Company**  
-  https://eclecticlight.co/category/macs/feed/
-
-- **Managing OS X**  
-  http://managingosx.wordpress.com/feed/
-
-- **Marriott Library - Apple Infrastructure**  
-  https://apple.lib.utah.edu/feed/
-
-- **MOD TITAN**  
-  http://www.modtitan.com/feeds/posts/default?alt=rss
-
-- **Mr. Macintosh**  
-  https://mrmacintosh.com/feed/
-
-- **r/macsysadmin**  
-  https://api.reddit.com/subreddit/macsysadmin
-
-- **Richard Purves**  
-  hhttps://richard-purves.com/feed
-
-- **Scripting OS X**  
-  http://scriptingosx.com/feed/
-
-- **SecureMac**  
-  https://www.securemac.com/feed
-
-- **Sound Mac Guy**  
-  https://soundmacguy.wordpress.com/feed/
-
-- **Travelling Tech Guy**  
-  https://travellingtechguy.eu/feed/
-
-- **News From Timo**  
-  https://tperfitt.twocanoes.com/feed.xml
-  
-- **MacAdmin Musings**  
-  https://macadminmusings.com/feed.xml  
-
-- **What The Mac?!**  
-  http://grahampugh.github.io/feed.xml
+- **1Password Status - Incident History**  
+  https://status.1password.com/history.rss
 
 ---
 
-## #blog-feed-lite
+## #addigy
 
-- **mike solin's blog**  
-  https://mikesolin.com/feed/
+- **Addigy Status - Incident History**  
+  https://status.addigy.com/history.rss
 
----
-
-## #apple-rumors
-
-- **9to5Mac**  
-  http://9to5mac.com/feed.xml
-
-- **MacRumors: Mac News and Rumors**  
-  https://feeds.macrumors.com/MacRumors-All 
-  
-  - **Jamf Press Releases**  
-  https://www.jamf.com/press-releases/rss/
-  
-  
----
-
-## #jamfnation
-
-- **Jamf Status - Incident History**  
-  https://status.jamf.com/history.rss
-
+- **Latest Addigy Updates**  
+  https://releases.addigy.com/rss/features
 
 ---
 
-## #jamf-community-post
+## #addigy-pub-software
 
-- **Jamf Blog**  
-  http://www.jamf.com/blog/rss/
+- **Latest Addigy Updates**  
+  https://releases.addigy.com/rss/software-library
 
-- **Jamf Press Releases**  
-  https://www.jamf.com/press-releases/rss/
+---
+
+## #alectrona-patch-rss-feed
+
+- **Alectrona Patch Release Notes**  
+  https://patchdocs.alectrona.com/release-notes/rss.xml
+
+- **Newest Additions to the Patch Catalog**  
+  https://software.alectrona.com/patch/software.xml
+
+---
+
+## #app-catalog-updates
+
+- **App Catalog**  
+  https://feedback.appcatalog.cloud/api/v1/changelog/feed.rss
+
+- **App Catalog**  
+  https://appcatalog.cloud/apps/rss.xml
 
 ---
 
@@ -164,29 +60,162 @@ This file exists to enable rapid rebuilds if Slack RSS integrations are lost.
 - **Releases - Apple Developer**  
   https://developer.apple.com/news/releases/rss/releases.rss
 
+---
+
+## #apple-rumors
+
+- **Apple Newsroom**  
+  http://www.apple.com/pr/feeds/pr.rss
+
+- **Jamf Press Releases**  
+  https://www.jamf.com/press-releases/rss/
+
+- **MacRumors: Mac News and Rumors - All Stories**  
+  https://feeds.macrumors.com/MacRumors-All
 
 ---
 
-## #macadmpodcast
+## #blog-feed
+
+- **A blog about archives, storage and everything**  
+  https://macvfx.blog/feed
+
+- **Alan Siu's Blog**  
+  https://alansiu.net/feed
+
+- **Basic Apple Guy | Apple Wallpapers, Reviews, and Merch**  
+  https://www.basicappleguy.com/basicappleblog?format=rss
+
+- **Cannonball**  
+  https://tombridge.com/feed/rss
+
+- **Dan K. Snelson**  
+  https://snelson.us/feed/
+
+- **Der Flounder**  
+  https://derflounder.wordpress.com/feed/
+
+- **Elliot Jordan - "Macadmin" posts**  
+  https://www.elliotjordan.com/tags/macadmin/index.xml#feed
+
+- **Fleet blog | Fleet**  
+  https://fleetdm.com/rss/articles
+
+- **graham gilbert**  
+  https://grahamgilbert.com/index.xml
+
+- **Greater Philadelphia Mac Admins**  
+  https://phillymacadmins.com/feed/
+
+- **hmn**  
+  https://the.hmn.engineer/atom.xml
+
+- **Jamf Blog**  
+  http://www.jamf.com/blog/rss/
+
+- **jc0b.computer**  
+  https://jc0b.computer/index.xml
+
+- **Kitzy - mac admin**  
+  https://kitzy.com/tag/mac-admin/feed.xml
 
 - **Mac Admins Podcast**  
   http://podcast.macadmins.org/feed/
 
+- **MacAdmin Musings**  
+  https://macadminmusings.com/feed.xml
+
+- **MacAdmins.news**  
+  https://www.macadmins.news/rss/
+
+- **macadmins – dazwallace**  
+  https://dazwallace.wordpress.com/tag/macadmins/feed
+
+- **macmule**  
+  https://macmule.com/feed/
+
+- **Macs – The Eclectic Light Company**  
+  https://eclecticlight.co/category/macs/feed/
+
+- **Magic That Works**  
+  https://magicthatworks.net/blog/feed
+
+- **managing devices.**  
+  https://www.lashomb.com/rss.xml
+
+- **Marriott Library - Apple Infrastructure**  
+  https://apple.lib.utah.edu/feed/
+
+- **MOD TITAN**  
+  http://www.modtitan.com/feeds/posts/default?alt=rss
+
+- **MOD TITAN**  
+  https://www.modtitan.com/feeds/posts/default/-/mac%20admin?alt=rss
+
+- **Mr. Macintosh**  
+  https://mrmacintosh.com/feed/
+
+- **News - MacAdmins.org**  
+  https://www.macadmins.org/news?format=rss
+
+- **Patch Notes and Progress**  
+  https://tonyyo11.github.io/feed.xml
+
+- **Patrick van Nerum's blog**  
+  https://macosxbytes.wordpress.com/feed/
+
+- **Richard Purves**  
+  https://richard-purves.com/feed
+
+- **Scripting OS X**  
+  http://scriptingosx.com/feed/
+
+- **Sound Mac Guy**  
+  https://soundmacguy.wordpress.com/feed/
+
+- **Sound Mac Guy**  
+  https://soundmacguy.org.uk/feed.xml
+
+- **t-lark.github.io**  
+  https://t-lark.github.io/index.xml
+
+- **What The Mac?!**  
+  https://grahampugh.github.io/feed.xml
+
+- **Year of The Geek**  
+  http://yearofthegeek.net/feed
 
 ---
 
-## #sofa-rss-feed
+## #blog-feed-lite
 
-- **SOFA - RSS Update Feed**  
-  https://sofafeed.macadmins.io/v1/rss_feed.xml
+- **Elliot Jordan - "Macadmin" posts**  
+  https://www.elliotjordan.com/tags/macadmin/index.xml#feed
 
+- **jc0b.computer**  
+  https://jc0b.computer/index.xml
+
+- **MacAdmin Musings**  
+  https://macadminmusings.com/feed.xml
+
+- **mike solin's blog**  
+  https://mikesolin.com/feed/
+
+- **Sound Mac Guy**  
+  https://soundmacguy.wordpress.com/feed
+
+- **Sound Mac Guy**  
+  https://soundmacguy.org.uk/feed.xml
+
+- **What The Mac?!**  
+  https://grahampugh.github.io/feed.xml
 
 ---
 
-## #security-alerts
+## #chrome-release-rss
 
-_No feeds assigned yet._
-
+- **Google Chrome Releases**  
+  https://chromereleases.googleblog.com/feeds/posts/default?alt=rss
 
 ---
 
@@ -199,16 +228,63 @@ _No feeds assigned yet._
 
 ## #freegames-prime
 
-- **Free Amazon Prime Games (PC)*  
+- **Free Amazon Prime Games (PC)**  
   https://feed.eikowagenknecht.com/lootscraper_amazon_game.xml
 
 ---
 
-## #philly
+## #gam
 
-- **Greater Philadelphia Mac Admins**  
-  https://phillymacadmins.com/feed/
+- **Release notes from GAM**  
+  https://github.com/GAM-team/GAM/releases.atom
 
+---
+
+## #google-workspace-updates-rss
+
+- **Google Workspace Updates**  
+  https://feeds.feedburner.com/GoogleAppsUpdates
+
+---
+
+## #iru
+
+- **Kandji Product Updates**  
+  https://www.iru.com/updates/feed
+
+- **Kandji Status - Incident History**  
+  https://status.kandji.io/history.rss
+
+---
+
+## #jamf-community-posts
+
+- **Jamf Blog**  
+  http://www.jamf.com/blog/rss/
+
+- **Jamf Press Releases**  
+  https://www.jamf.com/press-releases/rss/
+
+---
+
+## #jamfnation
+
+- **Jamf Status - Incident History**  
+  https://status.jamf.com/history.rss
+
+---
+
+## #macadminsfoundation
+
+- **News - MacAdmins.org**  
+  https://www.macadmins.org/news?format=rss
+
+---
+
+## #macadmpodcast
+
+- **Mac Admins Podcast**  
+  http://podcast.macadmins.org/feed/
 
 ---
 
@@ -219,30 +295,38 @@ _No feeds assigned yet._
 
 ---
 
-## #app-catalog-updates
+## #philly
 
-- **App Catalog**  
-  https://feedback.appcatalog.cloud/api/v1/changelog/feed.rss
-  
-  
-- **App Catalog**  
-  https://appcatalog.cloud/apps/rss.xml 
+- **Greater Philadelphia Mac Admins**  
+  https://phillymacadmins.com/feed/
 
+---
+
+## #security-alerts
+
+- **Cyber Security Advisories - MS-ISAC**  
+  https://www.cisecurity.org/feed/advisories
+
+---
+
+## #sofa-rss-feed
+
+- **SOFA - RSS Update Feed**  
+  https://sofafeed.macadmins.io/v1/rss_feed.xml
 
 ---
 
 ## #tailscale
 
 - **Changelog on Tailscale**  
-  https://tailscale.com/changelog/index.xml  
-  
-
----
-
-## Unassigned / Needs Review
+  https://tailscale.com/changelog/index.xml
 
 ---
 
 # CHANGELOG
 
+- 2026-04-16: Full audit and rebuild against live Slack RSS feed list. Tony Young @tonyyo11
+  - **Added:** A blog about archives, storage and everything (#blog-feed); Alan Siu's Blog (#blog-feed); Addigy Status - Incident History (#addigy); Latest Addigy Updates (#addigy, #addigy-pub-software); Alectrona Patch Release Notes (#alectrona-patch-rss-feed); Newest Additions to the Patch Catalog (#alectrona-patch-rss-feed); Elliot Jordan - "Macadmin" posts (#blog-feed, #blog-feed-lite); Fleet blog | Fleet (#blog-feed); Google Chrome Releases (#chrome-release-rss); Google Workspace Updates (#google-workspace-updates-rss); hmn (#blog-feed); 1Password Status - Incident History (#1password); Kandji Status - Incident History (#iru); Kandji Product Updates (#iru); jc0b.computer (#blog-feed, #blog-feed-lite); Kitzy - mac admin (#blog-feed); macadmins – dazwallace (#blog-feed); MacAdmin Musings (#blog-feed-lite); Magic That Works (#blog-feed); News - MacAdmins.org (#macadminsfoundation, #blog-feed); Patrick van Nerum's blog (#blog-feed); Release notes from GAM (#gam); Sound Mac Guy (soundmacguy.org.uk feed added to #blog-feed and #blog-feed-lite); t-lark.github.io (#blog-feed); What The Mac?! (#blog-feed-lite); MOD TITAN second URL (mac admin filtered feed)
+  - **Updated:** Apple Newsroom moved from #blog-feed to #apple-rumors; MacAdmins.news URL updated (macadmins.news/issues.rss → www.macadmins.news/rss/); macmule URL updated to https; Cannonball URL updated (cannonball.tombridge.com → tombridge.com/feed/rss); MacRumors name corrected to include "- All Stories"; Richard Purves URL typo fixed (hhttps → https); #jamf-community-post corrected to #jamf-community-posts
+  - **Removed (no longer active):** Command Control Power; Command Line – OS X Daily; krypted; Latest News - Apple Developer (old iphonedevnews.rss URL); Managing OS X; r/macsysadmin; SecureMac; Travelling Tech Guy; News From Timo; HCS Technology Group (both entries); 9to5Mac
 - 2026-01-13: Initial Generation of List. Tony Young @tonyyo11


### PR DESCRIPTION
Updated the Slack RSS Feeds for latest listings - April 16th, 2026